### PR TITLE
Wildcard dependency on resources plugin

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -25,6 +25,6 @@ grails.project.dependency.resolution = {
       build(":tomcat:$grailsVersion", ":release:2.2.0", ":rest-client-builder:1.0.3") {
           export = false
       }
-      runtime ":resources:1.1.6"
+      runtime ":resources:[1.1.6,)"
     }
 }


### PR DESCRIPTION
Changing the hard dependency on 1.1.6 version on resources plugin to version >= 1.1.6
